### PR TITLE
Remove generator option from book.json

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,4 @@
 {
-    "generator": "site",
     "title": "SystemDocs",
     "description": "System Documents",
     "github": null,


### PR DESCRIPTION
If you look at [the README of gitbook](https://github.com/GitbookIO/gitbook#how-to-use-it), it says:

`// Generator to use for building`
`// Caution: it overrides the value from the command line`
`// It's not advised this option in the book.json`
`"generator": "site",`

For example, if I want to run the `gitbook pdf`command to convert the gitbook to a PDF, it doesn't work when the generator option is specified to be `site` in the book.json because book.json will override the value from the command line (for example, `pdf`) with `site` instead.

So I get the following error:
`Starting build ...`
`ENOENT, lstat '/var/folders/ld/z9_z78d11m57k250mryfnx_h0000gn/T/tmp-37086ama1eyo/index.pdf'`

The way to fix this is to simply remove the generator option from book.json. So until now I have removed it manually whenever I want to convert the gitbook to a PDF. But then other people ask me how I did it and when I explain them how to do it, I need to tell them to manually remove the generator option from book.json and this adds more friction to the process. As for as I know, there is no good reason to specify the generator option to be `site` in book.json, since `site` is the default value anyways.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/systemdocs/3)

<!-- Reviewable:end -->
